### PR TITLE
Migrate to a worker thread with prompt cancellation

### DIFF
--- a/src/linuxX64Main/kotlin/com/kevincianfarini/iouring/internal/interrupt.kt
+++ b/src/linuxX64Main/kotlin/com/kevincianfarini/iouring/internal/interrupt.kt
@@ -1,0 +1,39 @@
+package com.kevincianfarini.iouring.internal
+
+import kotlinx.cinterop.staticCFunction
+import kotlinx.coroutines.*
+import liburing.SIGINT
+import liburing.pthread_kill
+import liburing.pthread_t
+import platform.posix.pthread_self
+import platform.posix.signal
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * A rudimentary implementation of runInterruptible similar to Kotlin/JVM's implementation.
+ * This function will run [block] within [coroutineContext]. Upon cancellation, this function
+ * will send a [signal] to the underlying thread of [coroutineContext] via [pthread_kill].
+ *
+ * Successful usage of this function assumes that [block] can be interrupted from an operating
+ * system signal. Usage which does not respect signals may hang or deadlock.
+ */
+internal suspend fun <T> runInterruptible(
+    signal: Int = SIGINT,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    block: () -> T
+) {
+    val thread = withContext(coroutineContext) { pthread_self() }
+    signal(signal, staticCFunction<Int, Unit> {
+        throw CancellationException("SIGINT!")
+    })
+    return coroutineScope {
+        launch { interruptWhenCancelled(thread, signal) }
+        withContext(coroutineContext) { block() }
+    }
+}
+private suspend fun interruptWhenCancelled(thread: pthread_t, signal: Int): Nothing {
+    suspendCancellableCoroutine<Nothing> { cont ->
+        cont.invokeOnCancellation { pthread_kill(thread, signal) }
+    }
+}


### PR DESCRIPTION
Prior to this commit this library was busy polling for io_uring CQEs.
This was not ideal because when the process was idle and waiting for new
CQEs, like when a server is waiting to `accept` a new connection, 100%
of a single core's CPU resources were used busy polling.
See: db05a159f1eecd3c9c9bbbb92a8f6a37e66c3f2f

Prior to even that commit we _were_ using a worker thread to block and
wait for new CQEs, but that proved difficult. There's no easy way to
instruct a liburing call to stop blocking and that it has been
interrupted from Kotlin/Native. To cope with that limitation at the time
I used the `io_uring_wait_cqe_timeout` function instead with an
arbitrary 100ms timeout. This felt clumsy and also breaks Kotlin's
_prompt cancellation guarantee_ for cancellation.

This commit gets signals working in Kotlin/Native, but I am unsure if
it's the proper solution. Quite honestly, I stumbled into it when doing
some print debugging.

We initialize the single threaded `CoroutineDispatcher` on `init` of the
class and grab the `pthread_self` value from its context. We leverage
that thread reference from the 'main' thread in a coroutine that
suspends until the `KernelURing` is cancelled or closed. When cancelled,
we `pthread_kill` with a `SIGINT`. This is where things get weird:

On the blocking worker thread we've installed a singal handler via the
libc `signal` API and a Kotlin/Native `staticCFunction`. Based on my
understanding of signal handlers, since the signal is intercepted, I
expected that we would have to manually call `pthread_exit` to
gracefully exit the thread underlying the `CoroutineDispatcher`. Doing
so crashed the Kotlin/Native runtime. _Omitting_ a call to
`pthread_exit` works as expected though, which I do not understand why.
